### PR TITLE
Update FoodTemplate.cs

### DIFF
--- a/SRML/SR/Templates/Identifiables/FoodTemplate.cs
+++ b/SRML/SR/Templates/Identifiables/FoodTemplate.cs
@@ -149,7 +149,7 @@ namespace SRML.SR.Templates.Identifiables
         }
 
         /// <summary>
-        /// Sets the translation for this slime's name
+        /// Sets the translation for this food's name
         /// </summary>
         /// <param name="name">The translated name</param>
         public override FoodTemplate SetTranslation(string name)


### PR DESCRIPTION
Correct summary for FoodTemplate.SetTranslation() to indicate that it sets a translation for the name of a food. Previously, it said "Sets the translation for this slime's name."