### PR TITLE
Update Harmony from 1.2.0.1 to 2.0.1

### DIFF
--- a/SRML/SR/Patches/SRInputConstructorPatch.cs
+++ b/SRML/SR/Patches/SRInputConstructorPatch.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace SRML.SR.Patches
 {
-    [HarmonyPatch(typeof(SRInput))]
+    [HarmonyPatch]
     internal static class SRInputConstructorPatch
     {
         public static MethodBase TargetMethod()

--- a/SRML/SR/Patches/UpgradePurchaseUIPatch.cs
+++ b/SRML/SR/Patches/UpgradePurchaseUIPatch.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace SRML.SR.Patches
 {
-    [HarmonyPatch(typeof(PersonalUpgradeUI))]
+    [HarmonyPatch]
     internal static class UpgradePurchaseUIPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/SR/SaveSystem/Patches/BuildActorDataPatch.cs
+++ b/SRML/SR/SaveSystem/Patches/BuildActorDataPatch.cs
@@ -13,7 +13,7 @@ using VanillaActorData = MonomiPark.SlimeRancher.Persist.ActorDataV09;
 
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(SavedGame))]
+    [HarmonyPatch]
     internal static class BuildActorDataPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/SR/SaveSystem/Patches/LoadFallBackSavePatch.cs
+++ b/SRML/SR/SaveSystem/Patches/LoadFallBackSavePatch.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(AutoSaveDirector))]
+    [HarmonyPatch]
     // Need to get rid of 4 instructions after savedgame load 
     internal static class LoadFallBackSavePatch
     {

--- a/SRML/SR/SaveSystem/Patches/LoadSavePatch.cs
+++ b/SRML/SR/SaveSystem/Patches/LoadSavePatch.cs
@@ -11,7 +11,7 @@ using UnityEngine;
 
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(AutoSaveDirector))]
+    [HarmonyPatch]
     internal static class LoadSavePatch
     {
         private static Type targetType = typeof(AutoSaveDirector).GetNestedTypes(BindingFlags.NonPublic)

--- a/SRML/SR/SaveSystem/Patches/PullGadgetDataPatch.cs
+++ b/SRML/SR/SaveSystem/Patches/PullGadgetDataPatch.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 using VanillaGadgetData = MonomiPark.SlimeRancher.Persist.PlacedGadgetV08;
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(SavedGame))]
+    [HarmonyPatch]
     internal static class PullGadgetDataPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/SR/SaveSystem/Patches/PullLandPlotDataPatch.cs
+++ b/SRML/SR/SaveSystem/Patches/PullLandPlotDataPatch.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 using VanillaLandPlotData = MonomiPark.SlimeRancher.Persist.LandPlotV08;
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(SavedGame))]
+    [HarmonyPatch]
     internal static class PullLandPlotDataPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/SR/SaveSystem/Patches/PushActorDataPatch.cs
+++ b/SRML/SR/SaveSystem/Patches/PushActorDataPatch.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 using VanillaActorData = MonomiPark.SlimeRancher.Persist.ActorDataV09;
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(SavedGame))]
+    [HarmonyPatch]
     internal static class PushActorDataPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/SR/SaveSystem/Patches/PushGadgetPatch.cs
+++ b/SRML/SR/SaveSystem/Patches/PushGadgetPatch.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 using VanillaGadgetData = MonomiPark.SlimeRancher.Persist.PlacedGadgetV08;
 namespace SRML.SR.SaveSystem.Patches
 {
-    [HarmonyPatch(typeof(SavedGame))]
+    [HarmonyPatch]
     internal static class PushGadgetPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/SRML.csproj
+++ b/SRML/SRML.csproj
@@ -36,9 +36,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, PublicKeyToken=01a7d145a488a7d1, processorArchitecture=MSIL">
+    <Reference Include="0Harmony, Version=2.0.1.0, Culture=neutral, PublicKeyToken=null">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Desktop\0Harmony.dll</HintPath>
+      <HintPath>..\packages\Lib.Harmony.2.0.1\lib\net35\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SRML/Utils/Prefab/Patches/GameObjectInstantiatePatches.cs
+++ b/SRML/Utils/Prefab/Patches/GameObjectInstantiatePatches.cs
@@ -22,7 +22,7 @@ namespace SRML.Utils.Prefab.Patches
             }
         }
     }
-    [HarmonyPatch(typeof(UnityEngine.Object))]
+    [HarmonyPatch]
     internal static class InstantiateGenericPatch
     {
         public static MethodInfo TargetMethod()

--- a/SRML/packages.config
+++ b/SRML/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ini-parser" version="2.5.2" targetFramework="net35" />
+  <package id="Lib.Harmony" version="2.0.1" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
 </packages>

--- a/SampleMod/SampleMod.csproj
+++ b/SampleMod/SampleMod.csproj
@@ -35,9 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, PublicKeyToken=01a7d145a488a7d1, processorArchitecture=MSIL">
+    <Reference Include="0Harmony, Version=2.0.1.0, Culture=neutral, PublicKeyToken=null">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Desktop\0Harmony.dll</HintPath>
+      <HintPath>..\packages\Lib.Harmony.2.0.1\lib\net35\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\..\Program Files\Epic Games\SlimeRancher\SlimeRancher_Data\Managed\Assembly-CSharp.dll</HintPath>

--- a/SampleMod/packages.config
+++ b/SampleMod/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Lib.Harmony" version="1.2.0.1" targetFramework="net35" />
+  <package id="Lib.Harmony" version="2.0.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Harmony 2.0.1 Crashes if TargetMethod and an argument to the HarmonyPatchAttribute are present, this PR removes the additional data for those classes that and updates Harmony to 2.0.1 (Latest).