### PR TITLE
Slight improvements

### DIFF
--- a/SRML/SR/FoodGroupRegistry.cs
+++ b/SRML/SR/FoodGroupRegistry.cs
@@ -12,7 +12,7 @@ namespace SRML.SR
         {
             { x => Identifiable.IsFruit(x), SlimeEat.FoodGroup.FRUIT },
             { x => x.ToString().Contains("GINGER"), SlimeEat.FoodGroup.GINGER },
-            { x => Identifiable.IsAnimal(x), SlimeEat.FoodGroup.MEAT },
+            { x => Identifiable.MEAT_CLASS.Contains(x), SlimeEat.FoodGroup.MEAT },
             { x => Identifiable.IsSlime(x), SlimeEat.FoodGroup.NONTARRGOLD_SLIMES },
             { x => Identifiable.IsPlort(x), SlimeEat.FoodGroup.PLORTS },
             { x => Identifiable.IsVeggie(x), SlimeEat.FoodGroup.VEGGIES }

--- a/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
+++ b/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
@@ -55,8 +55,8 @@ namespace SRML.SR.Patches
 
             float value2 = __instance.pinkSnareWeight / (SnareRegistry.pinks.Count + 1);
 
-            for (var j = 0; j < SnareRegistry.pinks.Count; j++)
-                dictionary.Add(SnareRegistry.pinks[j], value2);
+            foreach (Identifiable.Id id in SnareRegistry.pinks)
+                dictionary.Add(id, value2);
 
             dictionary.Add(Identifiable.Id.PINK_GORDO, value2);
 

--- a/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
+++ b/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
@@ -21,7 +21,7 @@ namespace SRML.SR.Patches
             {
                 GordoIdentifiable gordo = gordoEntry.GetComponent<GordoIdentifiable>();
 
-                if (GordoRegistry.pinks.Contains(gordo.id) || gordo.id == Identifiable.Id.PINK_GORDO || !gordo.nativeZones.Any(HasAccessToZone))
+                if (SnareRegistry.pinks.Contains(gordo.id) || gordo.id == Identifiable.Id.PINK_GORDO || !gordo.nativeZones.Any(HasAccessToZone))
                     continue;
 
                 SlimeDiet diet = gordoEntry.GetComponent<GordoEat>().slimeDefinition.Diet;
@@ -53,10 +53,10 @@ namespace SRML.SR.Patches
                     dictionary.Add(favIds[j], value);
             }
 
-            float value2 = __instance.pinkSnareWeight / (GordoRegistry.pinks.Count + 1);
+            float value2 = __instance.pinkSnareWeight / (SnareRegistry.pinks.Count + 1);
 
-            for (var j = 0; j < GordoRegistry.pinks.Count; j++)
-                dictionary.Add(GordoRegistry.pinks[j], value2);
+            for (var j = 0; j < SnareRegistry.pinks.Count; j++)
+                dictionary.Add(SnareRegistry.pinks[j], value2);
 
             dictionary.Add(Identifiable.Id.PINK_GORDO, value2);
 

--- a/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
+++ b/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
@@ -1,0 +1,67 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SRML.SR.Patches
+{
+    [HarmonyPatch(typeof(GordoSnare), "GetGordoIdForBait")]
+    [HarmonyPriority(Priority.First)]
+    internal static class GordoSnareGetGordoIdPatch
+    {
+        private static readonly Func<Zone, bool> HasAccessToZone = ZoneDirector.HasAccessToZone;
+
+        public static bool Prefix(GordoSnare __instance, ref Identifiable.Id __result)
+        {
+            Dictionary<Identifiable.Id, float> dictionary = new Dictionary<Identifiable.Id, float>(Identifiable.idComparer);
+            List<Identifiable.Id> normalIds = new List<Identifiable.Id>();
+            List<Identifiable.Id> favIds = new List<Identifiable.Id>(); // To handle cases where multiple slimes favour the same id
+            Identifiable.Id baitId = __instance.GetPrivateField<SnareModel>("model").baitTypeId;
+
+            foreach (GameObject gordoEntry in GameContext.Instance.LookupDirector.GordoEntries)
+            {
+                GordoIdentifiable gordo = gordoEntry.GetComponent<GordoIdentifiable>();
+
+                if (GordoRegistry.pinks.Contains(gordo.id) || gordo.id == Identifiable.Id.PINK_GORDO || !gordo.nativeZones.Any(HasAccessToZone))
+                    continue;
+
+                SlimeDiet diet = gordoEntry.GetComponent<GordoEat>().slimeDefinition.Diet;
+                List<SlimeDiet.EatMapEntry> list2 = new List<SlimeDiet.EatMapEntry>();
+                diet.AddEatMapEntries(baitId, list2);
+                SlimeDiet.EatMapEntry eatMapEntry = list2.FirstOrDefault();
+
+                if (eatMapEntry == null)
+                    continue;
+
+                (string message, List<Identifiable.Id> ids) = eatMapEntry.isFavorite ? ("Found favorite", favIds) : ("Adding potential", normalIds);
+                Log.Debug(message, "gordo", gordo.id, "hasAccess", true); // Not using flag because the base game never even logs false here
+                ids.Add(gordo.id);
+            }
+
+            if (normalIds.Count > 0)
+            {
+                float value = __instance.foodTypeSnareWeight / normalIds.Count;
+
+                for (var j = 0; j < normalIds.Count; j++)
+                    dictionary.Add(normalIds[j], value);
+            }
+
+            if (favIds.Count > 0)
+            {
+                float value = __instance.favoredFoodSnareWeight / favIds.Count;
+
+                for (var j = 0; j < favIds.Count; j++)
+                    dictionary.Add(favIds[j], value);
+            }
+
+            float value2 = __instance.pinkSnareWeight / (GordoRegistry.pinks.Count + 1);
+
+            for (var j = 0; j < GordoRegistry.pinks.Count; j++)
+                dictionary.Add(GordoRegistry.pinks[j], value2);
+
+            dictionary.Add(Identifiable.Id.PINK_GORDO, value2);
+
+            __result = Randoms.SHARED.Pick(dictionary, Identifiable.Id.PINK_GORDO);
+            return false;
+        }
+    }
+}

--- a/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
+++ b/SRML/SR/Patches/GordoSnareGetGordoIdPatch.cs
@@ -60,8 +60,14 @@ namespace SRML.SR.Patches
 
             dictionary.Add(Identifiable.Id.PINK_GORDO, value2);
 
-            __result = Randoms.SHARED.Pick(dictionary, Identifiable.Id.PINK_GORDO);
+            Identifiable.Id pink = Randoms.SHARED.Pick(SnareRegistry.pinks);
+            __result = Randoms.SHARED.Pick(dictionary, pink);
             return false;
         }
+    }
+
+    private static T Pick<T>(this Randoms random, List<T> vals)
+    {
+        return vals[random.GetInt(vals.Count)];
     }
 }

--- a/SRML/SR/Patches/GordoSnareOnTriggerPatch.cs
+++ b/SRML/SR/Patches/GordoSnareOnTriggerPatch.cs
@@ -5,6 +5,7 @@ using System.Reflection.Emit;
 namespace SRML.SR.Patches
 {
     [HarmonyPatch(typeof(GordoSnare), "OnTriggerEnter")]
+    [HarmonyPriority(Priority.First)]
     internal static class GordoSnareOnTriggerPatch
     {
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instr)
@@ -24,6 +25,8 @@ namespace SRML.SR.Patches
             return instructions;
         }
 
-        public static bool IsSnareable(Identifiable.Id identifiable) => SnareRegistry.snareables.Contains(identifiable) || Identifiable.IsFood(identifiable);
+        public static bool IsSnareable(Identifiable.Id identifiable) => Identifiable.IsFood(identifiable.id) // Vanilla behaviour
+            || SnareRegistry.snareables.Contains(identifiable.id) // Simple non food baits
+            || SnareRegistry.baitFuncs.Any(x => x(identifiable.id)); // More complex baits/batch id handling
     }
 }

--- a/SRML/SR/Patches/MailReadPatch.cs
+++ b/SRML/SR/Patches/MailReadPatch.cs
@@ -12,7 +12,7 @@ namespace SRML.SR.Patches
     {
         public static void Postfix(MailDirector __instance, MailDirector.Mail mail)
         {
-            MailRegistry.ModdedMails.FirstOrDefault((x) => mail.key == x.MailKey)?.onReadCallback(__instance, mail);
+            MailRegistry.ModdedMails.FirstOrDefault((x) => mail.key == x.MailKey)?.onReadCallback?.Invoke(__instance, mail);
         }
     }
 }

--- a/SRML/SR/SnareRegistry.cs
+++ b/SRML/SR/SnareRegistry.cs
@@ -8,7 +8,9 @@ namespace SRML.SR
 {
     public static class SnareRegistry
     {
-        internal static HashSet<Identifiable.Id> snareables = new HashSet<Identifiable.Id>(Identifiable.idComparer);
+        internal static readonly HashSet<Identifiable.Id> snareables = new();
+        internal static readonly HashSet<Func<Identifiable.Id, bool>> baitFuncs = new();
+        internal static readonly HashSet<Identifiable.Id> pinkLike = new();
 
         /// <summary>
         /// Allows an <see cref="Identifiable.Id"/> to go onto a gordo snare.
@@ -16,8 +18,25 @@ namespace SRML.SR
         /// <param name="id">The <see cref="Identifiable.Id"/> to register.</param>
         public static void RegisterAsSnareable(this Identifiable.Id id)
         {
-            if (!snareables.Contains(id)) 
-                snareables.Add(id);
+            snareables.Add(id);
+        }
+
+        /// <summary>
+        /// Registers a gordo to have similar bait behaviour as the pink gordo with gordo snares.
+        /// </summary>
+        /// <param name="gordoId">The id of the gordo being registered.</param>
+        public static void RegisterGordoWithPinkBehaviour(Identifiable.Id gordoId)
+        {
+            pinkLike.Add(gordoId);
+        }
+
+        /// <summary>
+        /// Registers a delegate that handles multiple ids/complex behaviour for bait ids.
+        /// </summary>
+        /// <param name="predicate">The id of the gordo being registered.</param>
+        public static void RegisterCollectiveBaitMethod(Func<Identifiable.Id, bool> predicate)
+        {
+            baitFuncs.Add(predicate);
         }
     }
 }

--- a/SRML/SR/SnareRegistry.cs
+++ b/SRML/SR/SnareRegistry.cs
@@ -8,9 +8,9 @@ namespace SRML.SR
 {
     public static class SnareRegistry
     {
-        internal static readonly HashSet<Identifiable.Id> snareables = new();
-        internal static readonly HashSet<Func<Identifiable.Id, bool>> baitFuncs = new();
-        internal static readonly HashSet<Identifiable.Id> pinkLike = new();
+        internal static readonly HashSet<Identifiable.Id> snareables = new HashSet<Identifiable.Id>(Identifiable.idComparer);
+        internal static readonly HashSet<Func<Identifiable.Id, bool>> baitFuncs = new HashSet<Func<Identifiable.Id, bool>>();
+        internal static readonly HashSet<Identifiable.Id> pinkLike = new HashSet<Identifiable.Id>(Identifiable.idComparer);
 
         /// <summary>
         /// Allows an <see cref="Identifiable.Id"/> to go onto a gordo snare.
@@ -18,7 +18,8 @@ namespace SRML.SR
         /// <param name="id">The <see cref="Identifiable.Id"/> to register.</param>
         public static void RegisterAsSnareable(this Identifiable.Id id)
         {
-            snareables.Add(id);
+            if (!snareables.Contains(id))
+                snareables.Add(id);
         }
 
         /// <summary>
@@ -27,7 +28,8 @@ namespace SRML.SR
         /// <param name="gordoId">The id of the gordo being registered.</param>
         public static void RegisterGordoWithPinkBehaviour(Identifiable.Id gordoId)
         {
-            pinkLike.Add(gordoId);
+            if (!pinkLike.Contains(gordoId))
+                pinkLike.Add(gordoId);
         }
 
         /// <summary>

--- a/SRML/SRML.csproj
+++ b/SRML/SRML.csproj
@@ -412,6 +412,7 @@
     <Compile Include="SR\Patches\ExchangeDirectorAwakePatch.cs" />
     <Compile Include="SR\Patches\GordoSnareOnTriggerPatch.cs" />
     <Compile Include="SR\Patches\GordoSnarePatch.cs" />
+    <Compile Include="SR\Patches\GordoSnareGetGordoIdPatch.cs" />
     <Compile Include="SR\Patches\LandPlotUpgradersPatch.cs" />
     <Compile Include="SR\Patches\GamepadPanelSetupBindingsPatch.cs" />
     <Compile Include="SR\Patches\ProgressDirectorPersonalUpgradeCheckPatch.cs" />

--- a/SRML/Utils/BinaryUtils.cs
+++ b/SRML/Utils/BinaryUtils.cs
@@ -235,12 +235,12 @@ namespace SRML.Utils
             return new Matrix4x4(ReadVector4(reader), ReadVector4(reader), ReadVector4(reader), ReadVector4(reader));
         }
 
-        public static void WriteArray(BinaryWriter writer, Array array, Action<BinaryWriter,object> writeAction)
+        public static void WriteArray<T>(BinaryWriter writer, T[] array, Action<BinaryWriter,T> writeAction)
         {
             writer.Write(array.Length);
             for (int i = 0; i < array.Length; i++)
             {
-                writeAction(writer, array.GetValue(i));
+                writeAction(writer, array[i);
             }
         }
 

--- a/SRML/Utils/BinaryUtils.cs
+++ b/SRML/Utils/BinaryUtils.cs
@@ -64,7 +64,7 @@ namespace SRML.Utils
             WriteArray(writer,mesh.bindposes,(x,y)=>WriteMatrix4(x,(Matrix4x4)y));
             WriteArray(writer,mesh.boneWeights,(x,y)=>WriteBoneWeight(x,(BoneWeight)y));
 
-            
+
         }
 
         public static void ReadMesh(BinaryReader reader, Mesh mesh)
@@ -227,7 +227,7 @@ namespace SRML.Utils
             {
                 WriteVector4(writer, matrix.GetColumn(i));
             }
-            
+
         }
 
         public static Matrix4x4 ReadMatrix4(BinaryReader reader)
@@ -240,7 +240,7 @@ namespace SRML.Utils
             writer.Write(array.Length);
             for (int i = 0; i < array.Length; i++)
             {
-                writeAction(writer, array[i);
+                writeAction(writer, array[i]);
             }
         }
 
@@ -250,13 +250,13 @@ namespace SRML.Utils
             T[] output = new T[length];
             for (int i = 0; i < length; i++)
             {
-                
+
                 output[i] = readAction(reader);
             }
 
             return output;
         }
-        
+
     }
 
     public class SerializerPair<T> : SerializerPair
@@ -282,7 +282,7 @@ namespace SRML.Utils
         public T DeserializeGeneric(BinaryReader reader)
         {
             return (T) Deserialize(reader);
-        } 
+        }
 
 
         private BinarySerializer<T> serializerFunc;


### PR DESCRIPTION
- Fixes modded chick IDs being registered as a meat food item (mainly happens for automatically patched ID values via `EnumHolderAttribute`)
- Allows devs to have a lack of an `onRead` event for modded mails, because why enforce it exactly?
- Genercizes the `BinaryUtils.WriteArray` method to ensure type safety and efficiency
- Updated the `SnareRegistry` class to allow custom gordos to behave like pink gordos and batch checking
- Added a patch to handle cases where multiple gordos favour the same bait food and pink gordo like behaviour